### PR TITLE
change header file include to lower case

### DIFF
--- a/src/htmlparser.cpp
+++ b/src/htmlparser.cpp
@@ -3,7 +3,7 @@
 // MIT License
 // ====================
 
-#include "include/HTMLParser.hpp"
+#include "include/htmlparser.hpp"
 
 #include <ranges>
 #include <regex>


### PR DESCRIPTION
from `HTMLparser.hpp` to `htmlparser.hpp` to support case sensitive systems like Linux and Mac